### PR TITLE
#3 Removed cl requirement.

### DIFF
--- a/exercism.el
+++ b/exercism.el
@@ -35,7 +35,6 @@
 
 ;;; Code:
 
-(require 'cl)
 (require 'url)
 (require 'json)
 


### PR DESCRIPTION
The cl package is already widely required (including by the json
package). Although it doesn't do any harm, I don't think it's a good
form to require it when the package doesn't actually use it.
